### PR TITLE
Always use CategoryOfRows as range of the Hom-structure of algebroids

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -19,7 +19,7 @@ Version := Maximum( [
                    ## this line prevents merge conflicts
                    "2019.10-30", ## Sepp's version
                    ## this line prevents merge conflicts
-                   "2021.07-02", ## Fabian's version
+                   "2021.07-03", ## Fabian's version
                    ] ),
 
 Date := ~.Version{[ 1 .. 10 ]},
@@ -132,8 +132,7 @@ Dependencies := rec(
                    [ "MonoidalCategories", ">= 2019.01.16" ],
                    [ "QPA", ">= 2.0" ],
                    [ "MatricesForHomalg", ">= 2017.05.25" ],
-                   [ "LinearAlgebraForCAP", ">= 2018.10.11" ],
-                   [ "FreydCategoriesForCAP", ">= 2019.11.02" ],
+                   [ "FreydCategoriesForCAP", ">= 2021.07-01" ],
                    [ "RingsForHomalg", ">= 2018.12.02" ],
                    ],
   SuggestedOtherPackages := [ ],

--- a/examples/doc/HomStructure.g
+++ b/examples/doc/HomStructure.g
@@ -36,7 +36,7 @@ maps = SetOfGeneratingMorphisms( Beilinson_P3, 1, 2 );
 Length( maps ) = 4;
 #! true
 ForAll( [ 0 .. 3 ], k ->
-        Dimension( HomomorphismStructureOnObjects( objs[1], objs[1 + k] ) )
+        RankOfObject( HomomorphismStructureOnObjects( objs[1], objs[1 + k] ) )
         = Binomial( 4 + k - 1, k )
 );
 #! true


### PR DESCRIPTION
The original code predates CAP commit 4000360eb9b04958bdbeb94d353b96043a0f8f40,
which made CategoryOfRows a full replacement for LinearAlgebraForCAP.

CC @sebastianpos and @kamalsaleh in case you would be affected by this.

I will provide a similar PR for QuiverRows once this is merged.