### PR TITLE
CoefficientsOfPaths does not seem to need Representative

### DIFF
--- a/gap/Algebroids.gi
+++ b/gap/Algebroids.gi
@@ -662,7 +662,7 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_HOM_STRUCTURE_OF_ALGEBROID,
   function( algebroid, over_Z )
     local quiver_algebra, quiver, vertices, basis, basis_paths_by_vertex_index, maps, path,
           MATRIX_FOR_HOMSTRUCTURE, hom_structure_on_basis_paths,
-          representative_func, ring, default_range_of_HomStructure, range_category,
+          ring, default_range_of_HomStructure, range_category,
           object_constructor, object_datum, morphism_constructor, morphism_datum;
     
     quiver_algebra := UnderlyingQuiverAlgebra( algebroid );
@@ -728,27 +728,13 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_HOM_STRUCTURE_OF_ALGEBROID,
         
         beta := PathAsAlgebraElement( quiver_algebra, path_2 );
         
-        if IsQuotientOfPathAlgebra( quiver_algebra ) then
+        for path in hom_v_w do
             
-            for path in hom_v_w do
-                
-                Add( mat,
-                  CoefficientsOfPaths( hom_vp_wp, Representative( alpha * PathAsAlgebraElement( quiver_algebra, path ) * beta ) )
-                );
-                
-            od;
+            Add( mat,
+                 CoefficientsOfPaths( hom_vp_wp, alpha * PathAsAlgebraElement( quiver_algebra, path ) * beta )
+                 );
             
-        else
-            
-            for path in hom_v_w do
-                
-                Add( mat,
-                  CoefficientsOfPaths( hom_vp_wp, ( alpha * PathAsAlgebraElement( quiver_algebra, path ) * beta ) )
-                );
-                
-            od;
-            
-        fi;
+        od;
         
         return mat;
         
@@ -775,17 +761,6 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_HOM_STRUCTURE_OF_ALGEBROID,
     SetHomStructureOnBasisPaths( algebroid, hom_structure_on_basis_paths );
     
     Assert( 0, IsIdenticalObj( hom_structure_on_basis_paths, HomStructureOnBasisPaths( algebroid ) ) );
-    
-    ##
-    if IsQuotientOfPathAlgebra( quiver_algebra ) then
-        
-        representative_func := Representative;
-        
-    else
-        
-        representative_func := IdFunc;
-        
-    fi;
     
     ring := CommutativeRingOfLinearCategory( algebroid );
     
@@ -947,7 +922,7 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_HOM_STRUCTURE_OF_ALGEBROID,
         return morphism_constructor(
                 range_category,
                 source,
-                HomalgMatrixListList( [ CoefficientsOfPaths( basis_elements, representative_func( element ) ) ], 1, size_basis, ring ),
+                HomalgMatrixListList( [ CoefficientsOfPaths( basis_elements, element ) ], 1, size_basis, ring ),
                 range
               );
         
@@ -1001,7 +976,7 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_HOM_STRUCTURE_OF_ALGEBROID,
         
         element := UnderlyingQuiverAlgebraElement( morphism );
         
-        return CoefficientsOfPaths( BasisPathsByVertexIndex( algebroid )[nr_source][nr_range], representative_func( element ) );
+        return CoefficientsOfPaths( BasisPathsByVertexIndex( algebroid )[nr_source][nr_range], element );
         
     end );
     

--- a/gap/precompiled_categories/AdditiveClosureOfAlgebroidOfFiniteDimensionalQuotientOfPathAlgebraOfRightQuiverOverFieldPrecompiled.gi
+++ b/gap/precompiled_categories/AdditiveClosureOfAlgebroidOfFiniteDimensionalQuotientOfPathAlgebraOfRightQuiverOverFieldPrecompiled.gi
@@ -367,10 +367,8 @@ function ( cat_1, source_1, alpha_1, range_1 )
     deduped_8_1 := BasisPathsByVertexIndex( UnderlyingCategory( cat_1 ) );
     hoisted_7_1 := deduped_10_1;
     hoisted_6_1 := [ 1 .. Length( ObjectList( Range( alpha_1 ) ) ) ];
-    hoisted_5_1 := List( deduped_11_1, function ( logic_new_func_x_2 )
-            return List( logic_new_func_x_2, function ( logic_new_func_x_3 )
-                    return Representative( UnderlyingQuiverAlgebraElement( logic_new_func_x_3 ) );
-                end );
+    hoisted_5_1 := List( deduped_11_1, function ( logic_new_func_list_2 )
+            return List( logic_new_func_list_2, UnderlyingQuiverAlgebraElement );
         end );
     hoisted_4_1 := deduped_8_1;
     hoisted_3_1 := List( deduped_11_1, function ( logic_new_func_x_2 )

--- a/gap/precompiled_categories/AdditiveClosureOfAlgebroidOfFiniteDimensionalQuotientOfPathAlgebraOfRightQuiverOverZPrecompiled.gi
+++ b/gap/precompiled_categories/AdditiveClosureOfAlgebroidOfFiniteDimensionalQuotientOfPathAlgebraOfRightQuiverOverZPrecompiled.gi
@@ -367,10 +367,8 @@ function ( cat_1, source_1, alpha_1, range_1 )
     deduped_8_1 := BasisPathsByVertexIndex( UnderlyingCategory( cat_1 ) );
     hoisted_7_1 := deduped_10_1;
     hoisted_6_1 := [ 1 .. Length( ObjectList( Range( alpha_1 ) ) ) ];
-    hoisted_5_1 := List( deduped_11_1, function ( logic_new_func_x_2 )
-            return List( logic_new_func_x_2, function ( logic_new_func_x_3 )
-                    return Representative( UnderlyingQuiverAlgebraElement( logic_new_func_x_3 ) );
-                end );
+    hoisted_5_1 := List( deduped_11_1, function ( logic_new_func_list_2 )
+            return List( logic_new_func_list_2, UnderlyingQuiverAlgebraElement );
         end );
     hoisted_4_1 := deduped_8_1;
     hoisted_3_1 := List( deduped_11_1, function ( logic_new_func_x_2 )


### PR DESCRIPTION
this commit is meant to reduce the necessity to compile two version: one for path algebras and the other for quotients of path algebras

Currently Representative is still used in IsWellDefinedForMorphisms

This commit will not delete the compiled files which by now have equal content